### PR TITLE
fix: remove extra comma in buildspec

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -40,7 +40,7 @@ phases:
           "repository": "sagemaker-tensorflow-serving",
           "tags": [{
             "source": "1.11.1-cpu",
-            "dest": ["1.11.1-cpu", "1.11-cpu", , "1.11.1-cpu-'${CODEBUILD_BUILD_ID#*:}'"]
+            "dest": ["1.11.1-cpu", "1.11-cpu", "1.11.1-cpu-'${CODEBUILD_BUILD_ID#*:}'"]
           },{
             "source": "1.11.1-gpu",
             "dest": ["1.11.1-gpu", "1.11-gpu", "1.11.1-gpu-'${CODEBUILD_BUILD_ID#*:}'"]


### PR DESCRIPTION
*Issue #, if available:*

buildspec contained an extra comma that causes errors during CD builds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
