### PR TITLE
Change how single rows of CSV are handled

### DIFF
--- a/container/sagemaker/tensorflow-serving.js
+++ b/container/sagemaker/tensorflow-serving.js
@@ -168,38 +168,24 @@ function json_lines_request(r, data) {
 function csv_request(r) {
     var data = r.requestBody
 
-    // look for initial quote or numeric-only data in 1st field
-    var needs_quotes = data.search(/^\s*("|[\d.Ee+\-]+\s*,)/) != 0
-
     var lines = data.trim().split(/\r?\n/)
 
-    // start instances json - omit outer list for single example
-    var json = '{"instances":'
-    if (lines.length != 1) {
-        json += '['
-    }
+    var json = '{"instances":['
 
     for (var i = 0; i < lines.length; i++) {
         var line = lines[i].trim()
         if (line) {
             var instance = (i == 0) ? '[' : ',['
 
-            if (needs_quotes) {
-                instance += '"'
-                instance += line.replace(',', '","')
-                instance += '"'
-            } else {
-                instance += line
-            }
-
+            instance += line
             instance += ']'
 
             json += instance
         }
     }
 
-    // end instances json - omit outer list for single example
-    json += lines.length == 1 ? '}' : ']}'
+    // end instances json
+    json += ']}'
 
     tfs_json_request(r, json)
 }

--- a/test/integration/local/test_container.py
+++ b/test/integration/local/test_container.py
@@ -130,15 +130,27 @@ def test_predict_generic_json_two_instances():
 
 
 def test_predict_csv():
-    x = '1.0, 2.0, 5.0'
+    x = '1.0'
     y = make_request(x, 'text/csv')
-    assert y == {'predictions': [3.5, 4.0, 5.5]}
+    assert y == {'predictions': [[3.5]]}
 
 
-def test_predict_csv_two_instances():
-    x = '1.0, 2.0, 5.0\n1.0, 2.0, 5.0'
+def test_predict_csv_one_instance_three_values():
+    x = '1.0,2.0,5.0'
+    y = make_request(x, 'text/csv')
+    assert y == {'predictions': [[3.5, 4.0, 5.5]]}
+
+
+def test_predict_csv_two_instances_three_values():
+    x = '1.0,2.0,5.0\n1.0,2.0,5.0'
     y = make_request(x, 'text/csv')
     assert y == {'predictions': [[3.5, 4.0, 5.5], [3.5, 4.0, 5.5]]}
+
+
+def test_predict_csv_three_instances():
+    x = '1.0\n2.0\n5.0'
+    y = make_request(x, 'text/csv')
+    assert y == {'predictions': [[3.5], [4.0], [5.5]]}
 
 
 def test_regress():


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/sagemaker-tensorflow-serving-container/issues/20

*Description of changes:*

Turns single row of CSV into one instance.

One ambiguous case is one row with only one column, which is serialized as `{"instances":[["foo"]]}` and not `{"instances":["foo"]}`, so the response is `{'predictions': [[3.5]]}` instead of `{'predictions': [3.5]}`, not sure which is preferable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
