### PR TITLE
fix: update EI binary location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 __pycache__
 .tox/
 log.txt
-container/AmazonEI_TensorFlow_Serving*
+container/amazonei_tensorflow_model_server
+.idea/
+docker/dev

--- a/docker/Dockerfile.eia
+++ b/docker/Dockerfile.eia
@@ -3,7 +3,7 @@ LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
 
 ARG TFS_SHORT_VERSION
 
-COPY AmazonEI_TensorFlow_Serving_v${TFS_SHORT_VERSION}_v1 /usr/bin/tensorflow_model_server
+COPY amazonei_tensorflow_model_server /usr/bin/tensorflow_model_server
 
 # downloaded 1.12 version is not executable
 RUN chmod +x /usr/bin/tensorflow_model_server
@@ -19,7 +19,7 @@ RUN \
     apt-get clean
 
 COPY ./ /
-RUN rm AmazonEI_TensorFlow_Serving_v${TFS_SHORT_VERSION}_v1
+RUN rm amazonei_tensorflow_model_server
 
 ENV SAGEMAKER_TFS_VERSION "${TFS_SHORT_VERSION}"
 ENV PATH "$PATH:/sagemaker"

--- a/scripts/shared.sh
+++ b/scripts/shared.sh
@@ -40,7 +40,7 @@ function get_tfs_executable() {
     mkdir exec_dir
     unzip ${zip_file} -d exec_dir
 
-    find . -name AmazonEI_TensorFlow_Serving_v${short_version}_v1* -exec mv {} container/ \;
+    find . -name amazonei_tensorflow_model_server -exec mv {} container/ \;
     rm ${zip_file} && rm -rf exec_dir
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
AmazonEI binary changed name to `amazonei_tensorflow_model_server`, update Dockerfile.eia accordingly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
