### PR TITLE
Handle zero values correctly

### DIFF
--- a/container/sagemaker/tensorflow-serving.js
+++ b/container/sagemaker/tensorflow-serving.js
@@ -196,7 +196,12 @@ function csv_request(r) {
 }
 
 function handle_numeric_values(arg) {
-    return parseFloat(arg) || arg
+    var parsed = parseFloat(arg)
+    if (isNaN(parsed)) {
+        return arg
+    } else {
+        return parsed;
+    }
 }
 
 function csv_split(s) {

--- a/test/integration/local/test_container.py
+++ b/test/integration/local/test_container.py
@@ -135,6 +135,18 @@ def test_predict_csv():
     assert y == {'predictions': [3.5]}
 
 
+def test_predict_csv_with_zero():
+    x = '0.0'
+    y = make_request(x, 'text/csv')
+    assert y == {'predictions': [3.0]}
+
+
+def test_predict_csv_one_instance_three_values_with_zero():
+    x = '0.0,2.0,5.0'
+    y = make_request(x, 'text/csv')
+    assert y == {'predictions': [[3.0, 4.0, 5.5]]}
+
+
 def test_predict_csv_one_instance_three_values():
     x = '1.0,2.0,5.0'
     y = make_request(x, 'text/csv')


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

0.0 was being parsed as a String, not as a float, since 0.0 is falsey.

Oddly, this seems to improve performance, even relative to no parsing changes. I'm running this locally, so it's not a very controlled environment.

This is from `ab -k -n 10000 -c 16 -p test/resources/inputs/test.csv -T 'text/csv' http://localhost:8080/invocations`

```
Document Path:          /invocations
Document Length:        198 bytes

Concurrency Level:      16
Time taken for tests:   15.170 seconds
Complete requests:      10000
Failed requests:        0
Keep-Alive requests:    9908
Total transferred:      3529540 bytes
Total body sent:        2830000
HTML transferred:       1980000 bytes
Requests per second:    659.19 [#/sec] (mean)
Time per request:       24.272 [ms] (mean)
Time per request:       1.517 [ms] (mean, across all concurrent requests)
Transfer rate:          227.21 [Kbytes/sec] received
                        182.18 kb/s sent
                        409.39 kb/s total

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    0   0.1      0       2
Processing:     2   24  16.6     21     207
Waiting:        2   24  16.6     21     207
Total:          2   24  16.6     21     207

Percentage of the requests served within a certain time (ms)
  50%     21
  66%     25
  75%     29
  80%     32
  90%     41
  95%     54
  98%     73
  99%     89
 100%    207 (longest request)
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
