### PR TITLE
fix: improve handling of ei binary during builds

### DIFF
--- a/docker/Dockerfile.eia
+++ b/docker/Dockerfile.eia
@@ -3,11 +3,6 @@ LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
 
 ARG TFS_SHORT_VERSION
 
-COPY amazonei_tensorflow_model_server /usr/bin/tensorflow_model_server
-
-# downloaded 1.12 version is not executable
-RUN chmod +x /usr/bin/tensorflow_model_server
-
 # nginx + njs
 RUN \
     apt-get update && \
@@ -19,7 +14,8 @@ RUN \
     apt-get clean
 
 COPY ./ /
-RUN rm amazonei_tensorflow_model_server
+RUN mv amazonei_tensorflow_model_server /usr/bin/tensorflow_model_server && \
+    chmod +x /usr/bin/tensorflow_model_server
 
 ENV SAGEMAKER_TFS_VERSION "${TFS_SHORT_VERSION}"
 ENV PATH "$PATH:/sagemaker"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,9 +8,7 @@ source scripts/shared.sh
 
 parse_std_args "$@"
 
-if [ $arch = 'eia' ]; then
-    get_tfs_executable
-fi
+get_ei_executable
 
 echo "pulling previous image for layer cache... "
 $(aws ecr get-login --no-include-email --registry-id $aws_account) &>/dev/null || echo 'warning: ecr login failed'
@@ -25,3 +23,5 @@ docker build \
     -f docker/Dockerfile.$arch \
     -t $repository:$full_version-$device \
     -t $repository:$short_version-$device container
+
+remove_ei_executable


### PR DESCRIPTION
*Description of changes:*

- use tmpdir to download and extract ei files
- cleanup ei binary after container build
- decrease container size by removing redundant copy of ei binary

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
