### PR TITLE
fix: make njs code handle missing custom attributes header

### DIFF
--- a/container/sagemaker/tensorflow-serving.js
+++ b/container/sagemaker/tensorflow-serving.js
@@ -103,12 +103,14 @@ function parse_custom_attributes(r) {
     var attributes = {}
     var kv_pattern = /tfs-[a-z\-]+=[^,]+/g
     var header = r.headersIn[custom_attributes_header]
-    var matches = header.match(kv_pattern)
-    if (matches) {
-        for (var i = 0; i < matches.length; i++) {
-            var kv = matches[i].split('=')
-            if (kv.length === 2) {
-                attributes[kv[0]] = kv[1]
+    if (header) {
+        var matches = header.match(kv_pattern)
+        if (matches) {
+            for (var i = 0; i < matches.length; i++) {
+                var kv = matches[i].split('=')
+                if (kv.length === 2) {
+                    attributes[kv[0]] = kv[1]
+                }
             }
         }
     }

--- a/test/integration/local/test_container.py
+++ b/test/integration/local/test_container.py
@@ -210,3 +210,17 @@ def test_predict_bad_input_instances():
     x = json.dumps({'junk': 'data'})
     y = make_request(x)
     assert y['error'].startswith('Failed to process element: 0 key: junk of \'instances\' list.')
+
+
+def test_predict_no_custom_attributes_header():
+    x = {
+        'instances': [1.0, 2.0, 5.0]
+    }
+
+    headers = {
+        'Content-Type': 'application/json'
+    }
+    response = requests.post(BASE_URL, data=json.dumps(x), headers=headers)
+    y = json.loads(response.content.decode('utf-8'))
+
+    assert y == {'predictions': [3.5, 4.0, 5.5]}


### PR DESCRIPTION
*Description of changes:*

njs has started throwing errors when custom attributes header is not set:

```
*14 js exception: TypeError: cannot get property "match" of undefined
at parse_custom_attributes (tensorflow-serving.js:102)
at make_tfs_uri (tensorflow-serving.js:87)
at ping_tfs_1_11 (tensorflow-serving.js:35)
at ping (tensorflow-serving.js:16)
at main (native)
```

caused by change in behavior from `nginx-module-njs amd64 1.14.2.0.2.7-1~xenial` -> nginx-module-njs amd64 1.16.0.0.3.1-1~xenial` (njs 0.2.7 -> 0.3.1)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
