### PR TITLE
Add JSONLines accept type

### DIFF
--- a/container/sagemaker/tensorflow-serving.js
+++ b/container/sagemaker/tensorflow-serving.js
@@ -81,6 +81,7 @@ function tfs_json_request(r, json) {
 
         if (accept == 'application/jsonlines') {
             body = body.replace(/\n/g, '')
+            reply.headers['Content-Type'] = 'application/jsonlines'
         }
         r.return(reply.status, body)
     }

--- a/container/sagemaker/tensorflow-serving.js
+++ b/container/sagemaker/tensorflow-serving.js
@@ -79,9 +79,9 @@ function tfs_json_request(r, json) {
             body = body.replace("\\'instances\\'", "'instances'")
         }
 
-        if (accept == 'application/jsonlines') {
+        if ('application/jsonlines' == accept || 'application/jsons' == accept) {
             body = body.replace(/\n/g, '')
-            reply.headers['Content-Type'] = 'application/jsonlines'
+            r.headersOut['Content-Type'] = accept
         }
         r.return(reply.status, body)
     }

--- a/container/sagemaker/tensorflow-serving.js
+++ b/container/sagemaker/tensorflow-serving.js
@@ -71,6 +71,7 @@ function tfs_json_request(r, json) {
         body: json
     }
 
+    var accept = r.headersIn.Accept
     function callback (reply) {
         var body = reply.responseBody
         if (reply.status == 400) {
@@ -78,10 +79,14 @@ function tfs_json_request(r, json) {
             body = body.replace("\\'instances\\'", "'instances'")
         }
 
+        if (accept == 'application/jsonlines') {
+            body = body.replace(/\n/g, '')
+        }
         r.return(reply.status, body)
     }
 
     r.subrequest(uri, options, callback)
+
 }
 
 function make_tfs_uri(r, with_method) {

--- a/test/integration/local/test_container.py
+++ b/test/integration/local/test_container.py
@@ -252,4 +252,4 @@ def test_predict_with_jsonlines():
     }
     response = requests.post(BASE_URL, data=json.dumps(x), headers=headers)
     assert response.headers['Content-Type'] == 'application/jsonlines'
-    assert response.content.decode('utf-8') == '{    "predictions": [[3.5, 4.0], [4.5, 5.0]    ]}'
+    assert response.content.decode('utf-8') == '{    "predictions": [3.5, 4.0, 5.5    ]}'

--- a/test/integration/local/test_container.py
+++ b/test/integration/local/test_container.py
@@ -240,3 +240,17 @@ def test_predict_no_custom_attributes_header():
     y = json.loads(response.content.decode('utf-8'))
 
     assert y == {'predictions': [3.5, 4.0, 5.5]}
+
+def test_predict_with_jsonlines():
+    x = {
+        'instances': [1.0, 2.0, 5.0]
+    }
+
+    headers = {
+        'Content-Type': 'application/json',
+        'Accept':  'application/jsonlines'
+    }
+    response = requests.post(BASE_URL, data=json.dumps(x), headers=headers)
+    y = json.loads(response.content.decode('utf-8'))
+
+    assert y == '{    "predictions": [[3.5, 4.0], [4.5, 5.0]    ]}'

--- a/test/integration/local/test_container.py
+++ b/test/integration/local/test_container.py
@@ -251,6 +251,5 @@ def test_predict_with_jsonlines():
         'Accept':  'application/jsonlines'
     }
     response = requests.post(BASE_URL, data=json.dumps(x), headers=headers)
-    y = json.loads(response.content.decode('utf-8'))
-
-    assert y == '{    "predictions": [[3.5, 4.0], [4.5, 5.0]    ]}'
+    assert response.headers['Content-Type'] == 'application/jsonlines'
+    assert response.content.decode('utf-8') == '{    "predictions": [[3.5, 4.0], [4.5, 5.0]    ]}'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

If "application/jsonlines" is the Accept type, remove newlines. This is so that MultiRecord Batch can join these outputs by newlines and make a parseable JSONLines file.

Apache bench was within noise, for small payloads and for large payloads.

Also, I can't get local testing (with tox or pytest) to work without changing code -- is there more to it than building the images and running tox?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
