### PR TITLE
fix: use p2.xlarge by default in tests

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -19,7 +19,9 @@ phases:
       - ./scripts/build-all.sh
 
       # run local tests
-      - tox -e py36 -- -vv test/integration/local --framework-versions 1.11,1.12,1.13
+      - tox -e py36 -- test/integration/local --framework-version 1.11
+      - tox -e py36 -- test/integration/local --framework-version 1.12
+      - tox -e py36 -- test/integration/local --framework-version 1.13
 
       # push docker images to ECR
       - |

--- a/test/integration/local/conftest.py
+++ b/test/integration/local/conftest.py
@@ -10,16 +10,18 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+
 import pytest
 
-FRAMEWORK_LATEST_VERSION = '1.13'
+FRAMEWORK_LATEST_VERSION = '1.12'
 TFS_DOCKER_BASE_NAME = 'sagemaker-tensorflow-serving'
 
 
 def pytest_addoption(parser):
     parser.addoption('--docker-base-name', default=TFS_DOCKER_BASE_NAME)
-    parser.addoption('--framework-versions', default=FRAMEWORK_LATEST_VERSION)
-    parser.addoption('--arches', default='cpu')
+    parser.addoption('--framework-version', default=FRAMEWORK_LATEST_VERSION, required=True)
+    parser.addoption('--processor', default='cpu')
+    parser.addoption('--tag')
 
 
 @pytest.fixture(scope='module')
@@ -27,10 +29,24 @@ def docker_base_name(request):
     return request.config.getoption('--docker-base-name')
 
 
-def pytest_generate_tests(metafunc):
-    tags = list()
-    for arch in metafunc.config.getoption('--arches').split(','):
-        for version in metafunc.config.getoption('--framework-versions').split(','):
-            tags.append('{}-{}'.format(version, arch))
-    if 'tag' in metafunc.fixturenames:
-        metafunc.parametrize('tag', tags, scope='session')
+@pytest.fixture(scope='module')
+def framework_version(request):
+    return request.config.getoption('--framework-version')
+
+
+@pytest.fixture(scope='module')
+def processor(request):
+    return request.config.getoption('--processor')
+
+
+@pytest.fixture(scope='module')
+def enable_batch(request):
+    return request.config.getoption('--enable-batch') == 'True'
+
+
+@pytest.fixture(scope='module')
+def tag(request, framework_version, processor):
+    image_tag = request.config.getoption('--tag')
+    if not image_tag:
+        image_tag = '{}-{}'.format(framework_version, processor)
+    return image_tag

--- a/test/integration/local/conftest.py
+++ b/test/integration/local/conftest.py
@@ -13,7 +13,7 @@
 
 import pytest
 
-FRAMEWORK_LATEST_VERSION = '1.12'
+FRAMEWORK_LATEST_VERSION = '1.13'
 TFS_DOCKER_BASE_NAME = 'sagemaker-tensorflow-serving'
 
 

--- a/test/integration/local/test_python_service.py
+++ b/test/integration/local/test_python_service.py
@@ -47,7 +47,7 @@ def volume(tmpdir_factory, request):
 
 
 @pytest.fixture(scope='module', autouse=True)
-def container(volume, docker_base_name, tag):
+def container(request, volume, docker_base_name, tag):
     try:
         command = (
             'docker run --name sagemaker-tensorflow-serving-test -p 8080:8080'

--- a/test/integration/local/test_python_service.py
+++ b/test/integration/local/test_python_service.py
@@ -47,7 +47,7 @@ def volume(tmpdir_factory, request):
 
 
 @pytest.fixture(scope='module', autouse=True)
-def container(request, volume, docker_base_name, tag):
+def container(volume, docker_base_name, tag):
     try:
         command = (
             'docker run --name sagemaker-tensorflow-serving-test -p 8080:8080'


### PR DESCRIPTION
*Issue #, if available:*

This change also adds back the removed parameters for the local tests. The missing parameters is breaking one of our deployment pipeline

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
