### PR TITLE
fix: move SageMaker tests to release build

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -29,6 +29,9 @@ phases:
           ./scripts/publish-all.sh
         fi
 
+      # run SageMaker tests
+      - tox -e py36 -- -n 8 test/integration/sagemaker/test_tfs.py --versions 1.13.0
+
       # write deployment details to file
       # todo sort out eia versioning
       # todo add non-eia tests
@@ -56,7 +59,7 @@ phases:
             "dest": ["1.13.0-gpu", "1.13-gpu", "1.13.0-gpu-'${CODEBUILD_BUILD_ID#*:}'"]
           }],
           "test": [
-            "tox -e py36 -- -n 8 test/integration/sagemaker/test_tfs.py --versions 1.13.0 --region {region} --registry 520713654638"
+            "tox -e py36 -- -n 8 test/integration/sagemaker/test_tfs.py::test_tfs_model --versions 1.13.0 --region {region} --registry 520713654638"
           ]
         }, {
           "repository": "sagemaker-tensorflow-serving-eia",

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -30,7 +30,10 @@ phases:
         fi
 
       # run SageMaker tests
-      - tox -e py36 -- -n 8 test/integration/sagemaker/test_tfs.py --versions 1.13.0
+      - |
+        if is-release-build; then
+          tox -e py36 -- -n 8 test/integration/sagemaker/test_tfs.py --versions 1.13.0
+        fi
 
       # write deployment details to file
       # todo sort out eia versioning


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
running into throttling limits during deploy build. move the SM tests to release build and only run one test per container during deployment.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
