### PR TITLE
Update CPU Dockerfile with Ubuntu 18.04 as base

### DIFF
--- a/docker/1.13/Dockerfile.cpu
+++ b/docker/1.13/Dockerfile.cpu
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 LABEL maintainer="Amazon AI"
 LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
@@ -8,33 +8,16 @@ RUN \
     apt-get update && \
     apt-get -y install --no-install-recommends curl gnupg2 ca-certificates git wget vim build-essential zlib1g-dev && \
     curl -s http://nginx.org/keys/nginx_signing.key | apt-key add - && \
-    echo 'deb http://nginx.org/packages/ubuntu/ xenial nginx' >> /etc/apt/sources.list && \
+    echo 'deb http://nginx.org/packages/ubuntu/ bionic nginx' >> /etc/apt/sources.list && \
     apt-get update && \
-    apt-get -y install --no-install-recommends nginx nginx-module-njs && \
+    apt-get -y install --no-install-recommends nginx nginx-module-njs python3 python3-pip python3-setuptools && \ 
     apt-get clean
 
 # See http://bugs.python.org/issue19846
 ENV LANG C.UTF-8
 
-# Add arguments to achieve the version, python and url
-#  PYTHON=python for 2.7
-#  PYTHON=python3 for 3.5, 3.6 is not available directly on 16.04
 ARG PYTHON=python3
-
-# user python-pip or python3-pip
-ARG PYTHON_PIP=python3-pip
-
-#  PIP=pip for 2.7
-#  PIP=pip3 for 3.5, 3.6 is not available directly on 16.04
 ARG PIP=pip3
-ARG PYTHON_VERSION=3.6.6
-
-RUN wget https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tgz && \
-    tar -xvf Python-$PYTHON_VERSION.tgz && cd Python-$PYTHON_VERSION && \
-    ./configure && make && make install && \
-    apt-get update && apt-get install -y --no-install-recommends libreadline-gplv2-dev libncursesw5-dev libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev && \
-    make && make install && rm -rf ../Python-$PYTHON_VERSION* && \
-    ln -s /usr/local/bin/pip3 /usr/bin/pip
 
 # Python won’t try to write .pyc or .pyo files on the import of source modules
 ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1

--- a/docker/1.13/Dockerfile.cpu
+++ b/docker/1.13/Dockerfile.cpu
@@ -10,7 +10,7 @@ RUN \
     curl -s http://nginx.org/keys/nginx_signing.key | apt-key add - && \
     echo 'deb http://nginx.org/packages/ubuntu/ bionic nginx' >> /etc/apt/sources.list && \
     apt-get update && \
-    apt-get -y install --no-install-recommends nginx nginx-module-njs python3 python3-pip python3-setuptools && \ 
+    apt-get -y install --no-install-recommends nginx nginx-module-njs python3 python3-pip python3-setuptools && \
     apt-get clean
 
 # See http://bugs.python.org/issue19846


### PR DESCRIPTION
*Description of changes:*
1. Need to change apt-source type for nginx from ‘xenial’ to ‘bionic’ - minor change, done. 
2. 18.04 already ships with offical python3 repo, however, still trying to install 3.6.6 results in installation of tzdata - which (for some reason) requires user prompt to select timezone, which means automated build will fail.
3. To avoid point 2 above, simply install python3 from official repo, which all works fine. 

Removed the symlink for pip as it is no longer needed in 18.04.
The default pip and pip3 at location /usr/local/bin are just copies:

```
root@a97e70575134:/# whereis pip
pip: /usr/local/bin/pip3.6 /usr/local/bin/pip
root@a97e70575134:/# whereis pip3
pip3: /usr/bin/pip3 /usr/local/bin/pip3 /usr/local/bin/pip3.6
root@a97e70575134:/# which pip
/usr/local/bin/pip
root@a97e70575134:/# which pip3
/usr/local/bin/pip3
root@a97e70575134:/# ls -l $(which pip)
-rwxr-xr-x 1 root root 216 Jun 23 08:25 /usr/local/bin/pip
root@a97e70575134:/# ls -l $(which pip3)
-rwxr-xr-x 1 root root 216 Jun 23 08:25 /usr/local/bin/pip3
root@a97e70575134:/# cksum $(which pip3)
46964907 216 /usr/local/bin/pip3
root@a97e70575134:/# cksum $(which pip)
46964907 216 /usr/local/bin/pip
root@a97e70575134:/#
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
