### PR TITLE
fix: check gunicorn status before start nginx

### DIFF
--- a/container/sagemaker/serve.py
+++ b/container/sagemaker/serve.py
@@ -296,6 +296,10 @@ class ServiceManager(object):
         if self._use_gunicorn:
             self._setup_gunicorn()
             self._start_gunicorn()
+            while True:
+                if os.path.exists('/tmp/gunicorn.sock'):
+                    log.info('gunicorn server is ready!')
+                    break
 
         self._start_nginx()
         self._state = 'started'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
wait until gunicorn is ready before starting nginx

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
