### PR TITLE
fix: require defaul model env var

### DIFF
--- a/container/sagemaker/serve.py
+++ b/container/sagemaker/serve.py
@@ -44,7 +44,7 @@ class ServiceManager(object):
         self._tfs_version = os.environ.get('SAGEMAKER_TFS_VERSION', '1.13')
         self._nginx_http_port = os.environ.get('SAGEMAKER_BIND_TO_PORT', '8080')
         self._nginx_loglevel = os.environ.get('SAGEMAKER_TFS_NGINX_LOGLEVEL', 'error')
-        self._tfs_default_model_name = os.environ.get('SAGEMAKER_TFS_DEFAULT_MODEL_NAME', "None")
+        self._tfs_default_model_name = os.environ.get('SAGEMAKER_TFS_DEFAULT_MODEL_NAME', None)
 
         _enable_batching = os.environ.get('SAGEMAKER_TFS_ENABLE_BATCHING', 'false').lower()
         _enable_dynamic_endpoint = os.environ.get('SAGEMAKER_MULTI_MODEL',

--- a/test/integration/local/test_dynamic_endpoint.py
+++ b/test/integration/local/test_dynamic_endpoint.py
@@ -44,7 +44,7 @@ def container(request, docker_base_name, tag, runtime_config):
         command = (
             'docker run {}--name sagemaker-tensorflow-serving-test -p 8080:8080'
             ' --mount type=volume,source=dynamic_endpoint_model_volume,target=/opt/ml/models,readonly'
-            ' -e SAGEMAKER SAGEMAKER_TFS_DEFAULT_MODEL_NAME=half_plus_three'
+            ' -e SAGEMAKER_TFS_DEFAULT_MODEL_NAME=half_plus_three'
             ' -e SAGEMAKER_TFS_NGINX_LOGLEVEL=info'
             ' -e SAGEMAKER_BIND_TO_PORT=8080'
             ' -e SAGEMAKER_SAFE_PORT_RANGE=9000-9999'

--- a/test/integration/local/test_dynamic_endpoint.py
+++ b/test/integration/local/test_dynamic_endpoint.py
@@ -44,6 +44,7 @@ def container(request, docker_base_name, tag, runtime_config):
         command = (
             'docker run {}--name sagemaker-tensorflow-serving-test -p 8080:8080'
             ' --mount type=volume,source=dynamic_endpoint_model_volume,target=/opt/ml/models,readonly'
+            ' -e SAGEMAKER SAGEMAKER_TFS_DEFAULT_MODEL_NAME=half_plus_three'
             ' -e SAGEMAKER_TFS_NGINX_LOGLEVEL=info'
             ' -e SAGEMAKER_BIND_TO_PORT=8080'
             ' -e SAGEMAKER_SAFE_PORT_RANGE=9000-9999'


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Revert of #76 
- #76 tries to remove the constraints of SAGEMAKER_TFS_DEFAULT_MODEL_NAME, but the /ping check relies on default model.
- We will start a mail thread on the design decision (do healthcheck against TFS model server instead of default model in all cases, or make a logic to do healthcheck against model server instead of default model when multi-model is enabled.)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
