### PR TITLE
change: update publish-all.sh to match the versions in build-all.sh

### DIFF
--- a/scripts/publish-all.sh
+++ b/scripts/publish-all.sh
@@ -6,12 +6,9 @@ set -euo pipefail
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-${DIR}/publish.sh --version 1.11.1 --arch cpu
-${DIR}/publish.sh --version 1.11.1 --arch gpu
-${DIR}/publish.sh --version 1.12.0 --arch cpu
-${DIR}/publish.sh --version 1.12.0 --arch gpu
 ${DIR}/publish.sh --version 1.13.0 --arch cpu
 ${DIR}/publish.sh --version 1.13.0 --arch gpu
-${DIR}/publish.sh --version 1.11 --arch eia
-${DIR}/publish.sh --version 1.12 --arch eia
+${DIR}/publish.sh --version 1.14.0 --arch cpu
+${DIR}/publish.sh --version 1.14.0 --arch gpu
 ${DIR}/publish.sh --version 1.13 --arch eia
+${DIR}/publish.sh --version 1.14 --arch eia


### PR DESCRIPTION
*Description of changes:*
#85 changed `build-all.sh`, but `publish-all.sh` wasn't given the same treatment.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
