### PR TITLE
FIx the path for deep_learning_container.py in 2.0 Dockerfile

### DIFF
--- a/docker/2.0/Dockerfile.cpu
+++ b/docker/2.0/Dockerfile.cpu
@@ -91,7 +91,7 @@ RUN echo '#!/bin/bash \n\n' > /usr/bin/tf_serving_entrypoint.sh \
  && chmod +x /usr/bin/tf_serving_entrypoint.sh
 
 COPY dockerd-entrypoint.py /usr/local/bin/dockerd-entrypoint.py
-COPY deep_learning_container.py /usr/local/bin/deep_learning_container.py
+COPY /sagemaker/deep_learning_container.py /usr/local/bin/deep_learning_container.py
 
 RUN chmod +x /usr/local/bin/dockerd-entrypoint.py \
  && chmod +x /usr/local/bin/deep_learning_container.py

--- a/docker/2.0/Dockerfile.gpu
+++ b/docker/2.0/Dockerfile.gpu
@@ -122,7 +122,7 @@ RUN echo '#!/bin/bash \n\n' > /usr/bin/tf_serving_entrypoint.sh \
  && chmod +x /usr/bin/tf_serving_entrypoint.sh
 
 COPY dockerd-entrypoint.py /usr/local/bin/dockerd-entrypoint.py
-COPY deep_learning_container.py /usr/local/bin/deep_learning_container.py
+COPY /sagemaker/deep_learning_container.py /usr/local/bin/deep_learning_container.py
 
 RUN chmod +x /usr/local/bin/dockerd-entrypoint.py \
  && chmod +x /usr/local/bin/deep_learning_container.py


### PR DESCRIPTION
FIx the path for deep_learning_container.py in 2.0 Dockerfile.

changing from _deep_learning_container.py_ to _/sagemaker/deep_learning_container.py_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
