### PR TITLE
Filtering by numeric model versions.

### DIFF
--- a/docker/build_artifacts/sagemaker/tfs_utils.py
+++ b/docker/build_artifacts/sagemaker/tfs_utils.py
@@ -121,7 +121,7 @@ def find_models():
 
 
 def find_model_versions(model_path):
-    return [version.lstrip("0") for version in os.listdir(model_path)]
+    return [version.lstrip("0") for version in os.listdir(model_path) if version.isnumeric()]
 
 
 def _find_saved_model_files(path):


### PR DESCRIPTION
Recently, I experienced an issue in deploying the sagemaker serving container. I was getting the following:
```
[libprotobuf ERROR external/com_google_protobuf/src/google/protobuf/text_format.cc:317] Error parsing text-format tensorflow.serving.ModelServerConfig: 8:19: Expected integer, got: .
```
The above error was caused by some hidden folders that were included in the targz process that creates the model.
The issue has been introduced to the following PR: #155. I also see that there is already an open PR for excluding the `code` folder from the `find_model_versions` method (#160).

Instead of excluding explicitly the `code` folder I would prefer filtering by `version.isnumeric()`:

```
".0005".isnumeric() -> False
"code".isnumeric() -> False
"0005".isnumeric() -> True
"5".isnumeric() -> True
```

I have included a hidden folder + nested file as part of the testing model.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.