### PR TITLE
Extending the serve.py with GUNICORN workers and threads

### DIFF
--- a/docker/build_artifacts/sagemaker/serve.py
+++ b/docker/build_artifacts/sagemaker/serve.py
@@ -49,6 +49,8 @@ class ServiceManager(object):
         self._nginx_loglevel = os.environ.get("SAGEMAKER_TFS_NGINX_LOGLEVEL", "error")
         self._tfs_default_model_name = os.environ.get("SAGEMAKER_TFS_DEFAULT_MODEL_NAME", "None")
         self._sagemaker_port_range = os.environ.get("SAGEMAKER_SAFE_PORT_RANGE", None)
+        self._gunicorn_workers = os.environ.get("SAGEMAKER_GUNICORN_WORKERS", 1)
+        self._gunicorn_threads = os.environ.get("SAGEMAKER_GUNICORN_THREADS", 1)
         self._tfs_config_path = "/sagemaker/model-config.cfg"
         self._tfs_batching_config_path = "/sagemaker/batching-config.cfg"
 
@@ -169,9 +171,9 @@ class ServiceManager(object):
                         raise ChildProcessError("failed to install required packages.")
 
         gunicorn_command = (
-            "gunicorn -b unix:/tmp/gunicorn.sock -k gevent --chdir /sagemaker "
+            "gunicorn -b unix:/tmp/gunicorn.sock -k gevent --chdir /sagemaker --workers {} --threads {}"
             "{}{} -e TFS_GRPC_PORT={} -e SAGEMAKER_MULTI_MODEL={} -e SAGEMAKER_SAFE_PORT_RANGE={} "
-            "python_service:app").format(python_path_option, ",".join(python_path_content),
+            "python_service:app").format(self._gunicorn_workers, self._gunicorn_threads, python_path_option, ",".join(python_path_content),
                                          self._tfs_grpc_port, self._tfs_enable_multi_model_endpoint,
                                          self._sagemaker_port_range)
 

--- a/docker/build_artifacts/sagemaker/serve.py
+++ b/docker/build_artifacts/sagemaker/serve.py
@@ -171,7 +171,7 @@ class ServiceManager(object):
                         raise ChildProcessError("failed to install required packages.")
 
         gunicorn_command = (
-            "gunicorn -b unix:/tmp/gunicorn.sock -k gevent --chdir /sagemaker --workers {} --threads {}"
+            "gunicorn -b unix:/tmp/gunicorn.sock -k gevent --chdir /sagemaker --workers {} --threads {} "
             "{}{} -e TFS_GRPC_PORT={} -e SAGEMAKER_MULTI_MODEL={} -e SAGEMAKER_SAFE_PORT_RANGE={} "
             "python_service:app").format(self._gunicorn_workers, self._gunicorn_threads, python_path_option, ",".join(python_path_content),
                                          self._tfs_grpc_port, self._tfs_enable_multi_model_endpoint,

--- a/docker/build_artifacts/sagemaker/serve.py
+++ b/docker/build_artifacts/sagemaker/serve.py
@@ -171,9 +171,11 @@ class ServiceManager(object):
                         raise ChildProcessError("failed to install required packages.")
 
         gunicorn_command = (
-            "gunicorn -b unix:/tmp/gunicorn.sock -k gevent --chdir /sagemaker --workers {} --threads {} "
+            "gunicorn -b unix:/tmp/gunicorn.sock -k gevent --chdir /sagemaker "
+            "--workers {} --threads {} "
             "{}{} -e TFS_GRPC_PORT={} -e SAGEMAKER_MULTI_MODEL={} -e SAGEMAKER_SAFE_PORT_RANGE={} "
-            "python_service:app").format(self._gunicorn_workers, self._gunicorn_threads, python_path_option, ",".join(python_path_content),
+            "python_service:app").format(self._gunicorn_workers, self._gunicorn_threads,
+                                         python_path_option, ",".join(python_path_content),
                                          self._tfs_grpc_port, self._tfs_enable_multi_model_endpoint,
                                          self._sagemaker_port_range)
 


### PR DESCRIPTION
The following PR enables the `workers` and `threads` configuration in the gunicorn instance inside the sagemaker container.
I'm adding the following env variables `SAGEMAKER_GUNICORN_WORKERS` and `SAGEMAKER_GUNICORN_THREADS` with `1` as default, see [Worker processes](https://docs.gunicorn.org/en/stable/settings.html#worker-processes). This allows to run the instance of gunicorn with a customized worker and threads numbers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
