### PR TITLE
fix: install boto3

### DIFF
--- a/docker/1.15/Dockerfile.cpu
+++ b/docker/1.15/Dockerfile.cpu
@@ -54,7 +54,8 @@ RUN ${PIP} --no-cache-dir install --upgrade \
 
 # cython, falcon, gunicorn, grpc
 RUN ${PIP} install --no-cache-dir \
-    awscli==1.18.34 \
+    awscli \
+    boto3 \
     pyYAML==5.3.1 \
     cython==0.29.12 \
     falcon==2.0.0 \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

After building the container image of version 1.15, I tried to start the container but it did not work. Local tests showed that importing boto3 failed.

```console
$ tox -e py37 -- test/integration/local --framework-version 1.15 -vs                                                                   31.9s  Wed Nov 18 12:29:55 2020
/home/wukann/.cache/pypoetry/virtualenvs/sagemaker-tensorflow-serving-container-v95TaFz_-py3.6/lib/python3.6/site-packages/tox/config/__init__.py:647: UserWarning: conflicting basepython version (set 3.6, should be 3.7) for env 'py37';resolve conflict or set ignore_basepython_conflict
  testenv_config.envname,
py37 installed: apipkg==1.5,attrs==20.3.0,boto3==1.16.20,botocore==1.19.20,certifi==2020.11.8,chardet==3.0.4,execnet==1.7.1,idna==2.10,importlib-metadata==2.0.0,iniconfig==1.1.1,jmespath==0.10.0,packaging==20.4,pluggy==0.13.1,py==1.9.0,pyparsing==2.4.7,pytest==6.1.2,pytest-forked==1.3.0,pytest-xdist==2.1.0,python-dateutil==2.8.1,requests==2.25.0,s3transfer==0.3.3,six==1.15.0,toml==0.10.2,urllib3==1.26.2,zipp==3.4.0
py37 run-test-pre: PYTHONHASHSEED='471317051'
py37 run-test: commands[0] | python -m pytest test/integration/local --framework-version 1.15 -vs
========================================================================= test session starts =========================================================================
platform linux -- Python 3.6.12, pytest-6.1.2, py-1.9.0, pluggy-0.13.1 -- /home/wukann/work/sandbox/sagemaker-sdk/sagemaker-tensorflow-serving-container/.tox/py37/bin/python
cachedir: .tox/py37/.pytest_cache
rootdir: /home/wukann/work/sandbox/sagemaker-sdk/sagemaker-tensorflow-serving-container, configfile: tox.ini
plugins: forked-1.3.0, xdist-2.1.0
collected 101 items

test/integration/local/test_container.py::test_predict[True] model_volume
Traceback (most recent call last):
  File "/sagemaker/serve.py", line 14, in <module>
    import boto3
ModuleNotFoundError: No module named 'boto3'
FAILED
test/integration/local/test_container.py::test_predict_twice[True] FAILED
test/integration/local/test_container.py::test_predict_specific_versions[True] FAILED
...
```
With this fix, the above local test now passes.

I think other versions of container images need a similar fix.
In a recent PR (#172 ), the version 1.15 local tests were removed from the CI script (`buildspec.yml`), are there any rules about what version is being tested?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
