### PR TITLE
Remove the 1s lock for inference

### DIFF
--- a/docker/build_artifacts/sagemaker/python_service.py
+++ b/docker/build_artifacts/sagemaker/python_service.py
@@ -252,8 +252,7 @@ class PythonServiceResource:
         try:
             res.status = falcon.HTTP_200
 
-            with lock():
-                res.body, res.content_type = self._handlers(data, context)
+            res.body, res.content_type = self._handlers(data, context)
         except Exception as e:  # pylint: disable=broad-except
             log.exception("exception handling request: {}".format(e))
             res.status = falcon.HTTP_500


### PR DESCRIPTION
*Issue #, if available:*
Tensorflow Inference Container adding one second delay to all inference requests - Latency increases by 1 second

*Description of changes:*
Remove 1s lock for inference

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
