### PR TITLE
feature: expose tunable parameters to support multiple tfs

### DIFF
--- a/docker/1.13/Dockerfile.gpu
+++ b/docker/1.13/Dockerfile.gpu
@@ -102,6 +102,7 @@ RUN apt-get update \
 
 # cython, falcon, gunicorn, grpc
 RUN ${PIP} install -U --no-cache-dir \
+    boto3 \
     awscli==1.16.130 \
     cython==0.29.10 \
     falcon==2.0.0 \

--- a/docker/1.14/Dockerfile.gpu
+++ b/docker/1.14/Dockerfile.gpu
@@ -100,6 +100,7 @@ RUN apt-get update \
 
 # cython, falcon, gunicorn, grpc
 RUN ${PIP} install -U --no-cache-dir \
+    boto3 \
     awscli==1.16.196 \
     cython==0.29.12 \
     falcon==2.0.0 \

--- a/docker/1.15/Dockerfile.gpu
+++ b/docker/1.15/Dockerfile.gpu
@@ -92,6 +92,7 @@ RUN apt-get update \
 
 # cython, falcon, gunicorn, grpc
 RUN ${PIP} install -U --no-cache-dir \
+    boto3 \
     awscli==1.18.34 \
     pyYAML==5.3.1 \
     cython==0.29.12 \

--- a/docker/2.0/Dockerfile.gpu
+++ b/docker/2.0/Dockerfile.gpu
@@ -88,6 +88,7 @@ RUN apt-get update \
 
 # cython, falcon, gunicorn, grpc
 RUN ${PIP} install -U --no-cache-dir \
+    boto3 \
     awscli==1.16.303 \
     cython==0.29.14 \
     falcon==2.0.0 \

--- a/docker/2.1/Dockerfile.gpu
+++ b/docker/2.1/Dockerfile.gpu
@@ -90,6 +90,7 @@ RUN apt-get update \
 
 # cython, falcon, gunicorn, grpc
 RUN ${PIP} install -U --no-cache-dir \
+    boto3 \
     awscli \
     cython==0.29.14 \
     falcon==2.0.0 \

--- a/docker/build_artifacts/sagemaker/nginx.conf.template
+++ b/docker/build_artifacts/sagemaker/nginx.conf.template
@@ -18,7 +18,7 @@ http {
   js_include tensorflow-serving.js;
 
   upstream tfs_upstream {
-    server localhost:%TFS_REST_PORT%;
+    %TFS_UPSTREAM%;
   }
 
   upstream gunicorn_upstream {

--- a/docker/build_artifacts/sagemaker/python_service.py
+++ b/docker/build_artifacts/sagemaker/python_service.py
@@ -17,9 +17,11 @@ import logging
 import os
 import subprocess
 import time
+import grpc
 
 import falcon
 import requests
+import random
 
 from urllib3.util.retry import Retry
 
@@ -32,10 +34,10 @@ INFERENCE_SCRIPT_PATH = f"/opt/ml/{MODEL_DIR}/code/inference.py"
 
 SAGEMAKER_BATCHING_ENABLED = os.environ.get("SAGEMAKER_TFS_ENABLE_BATCHING", "false").lower()
 MODEL_CONFIG_FILE_PATH = "/sagemaker/model-config.cfg"
-TFS_GRPC_PORT = os.environ.get("TFS_GRPC_PORT")
-TFS_REST_PORT = os.environ.get("TFS_REST_PORT")
+TFS_GRPC_PORT_RANGE = os.environ.get("TFS_GRPC_PORT_RANGE")
+TFS_REST_PORT_RANGE = os.environ.get("TFS_REST_PORT_RANGE")
 SAGEMAKER_TFS_PORT_RANGE = os.environ.get("SAGEMAKER_SAFE_PORT_RANGE")
-
+TFS_INSTANCE_COUNT = int(os.environ.get("SAGEMAKER_TFS_INSTANCE_COUNT", "1"))
 
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger(__name__)
@@ -65,10 +67,19 @@ class PythonServiceResource:
             self._model_tfs_rest_port = {}
             self._model_tfs_grpc_port = {}
             self._model_tfs_pid = {}
-            self._tfs_ports = self._parse_sagemaker_port_range(SAGEMAKER_TFS_PORT_RANGE)
+            self._tfs_ports = self._parse_sagemaker_port_range_mme(SAGEMAKER_TFS_PORT_RANGE)
+            # If Multi-Model mode is enabled, dependencies/handlers will be imported
+            # during the _handle_load_model_post()
+            self.model_handlers = {}
         else:
-            self._tfs_grpc_port = TFS_GRPC_PORT
-            self._tfs_rest_port = TFS_REST_PORT
+            self._tfs_grpc_ports = self._parse_sagemaker_port_range(TFS_GRPC_PORT_RANGE)
+            self._tfs_rest_ports = self._parse_sagemaker_port_range(TFS_REST_PORT_RANGE)
+
+            self._channels = {}
+            for grpc_port in self._tfs_grpc_ports:
+                # Initialize grpc channel here so gunicorn worker could have mapping
+                # between each grpc port and channel
+                self._setup_channel(grpc_port)
 
         if os.path.exists(INFERENCE_SCRIPT_PATH):
             # Single-Model Mode & Multi-Model Mode both use one inference.py
@@ -90,6 +101,17 @@ class PythonServiceResource:
             self._handle_load_model_post(res, data)
 
     def _parse_sagemaker_port_range(self, port_range):
+        lower, upper = port_range.split('-')
+        lower = int(lower)
+        upper = int(upper)
+        if lower == upper:
+            return [lower]
+        return [lower + 2 * i for i in range(TFS_INSTANCE_COUNT)]
+
+    def _pick_port(self, ports):
+        return str(random.choice(ports))
+
+    def _parse_sagemaker_port_range_mme(self, port_range):
         lower, upper = port_range.split('-')
         lower = int(lower)
         upper = lower + int((int(upper) - lower) * 0.9)  # only utilizing 90% of the ports
@@ -239,15 +261,19 @@ class PythonServiceResource:
                     log.info("grpc port: {}".format(str(self._model_tfs_grpc_port[model_name])))
                     data, context = tfs_utils.parse_request(req, rest_port, grpc_port,
                                                             self._tfs_default_model_name,
-                                                            model_name)
+                                                            model_name=model_name)
             else:
                 res.status = falcon.HTTP_400
                 res.body = json.dumps({
                     "error": "Invocation request does not contain model name."
                 })
         else:
-            data, context = tfs_utils.parse_request(req, self._tfs_rest_port, self._tfs_grpc_port,
-                                                    self._tfs_default_model_name)
+            # Randomly pick port used for routing incoming request.
+            grpc_port = self._pick_port(self._tfs_grpc_ports)
+            rest_port = self._pick_port(self._tfs_rest_ports)
+            data, context = tfs_utils.parse_request(req, rest_port, grpc_port,
+                                                    self._tfs_default_model_name,
+                                                    channel=self._channels[int(grpc_port)])
 
         try:
             res.status = falcon.HTTP_200
@@ -259,6 +285,11 @@ class PythonServiceResource:
             res.body = json.dumps({
                 "error": str(e)
             }).encode("utf-8")  # pylint: disable=E1101
+
+    def _setup_channel(self, grpc_port):
+        if grpc_port not in self._channels:
+            log.info("Creating grpc channel for port: %s", grpc_port)
+            self._channels[grpc_port] = grpc.insecure_channel("localhost:{}".format(grpc_port))
 
     def _import_handlers(self):
         inference_script = INFERENCE_SCRIPT_PATH

--- a/docker/build_artifacts/sagemaker/serve.py
+++ b/docker/build_artifacts/sagemaker/serve.py
@@ -40,7 +40,7 @@ class ServiceManager(object):
     def __init__(self):
         self._state = "initializing"
         self._nginx = None
-        self._tfs = None
+        self._tfs = []
         self._gunicorn = None
         self._gunicorn_command = None
         self._enable_python_service = False
@@ -57,6 +57,12 @@ class ServiceManager(object):
         _enable_batching = os.environ.get("SAGEMAKER_TFS_ENABLE_BATCHING", "false").lower()
         _enable_multi_model_endpoint = os.environ.get("SAGEMAKER_MULTI_MODEL",
                                                       "false").lower()
+        # Use this to specify memory that is needed to initialize CUDA/cuDNN and other GPU libraries
+        self._tfs_gpu_margin = float(os.environ.get("SAGEMAKER_TFS_FRACTIONAL_GPU_MEM_MARGIN", 0.2))
+        self._tfs_instance_count = int(os.environ.get("SAGEMAKER_TFS_INSTANCE_COUNT", 1))
+        self._tfs_inter_op_parallelism = os.environ.get("SAGEMAKER_TFS_INTER_OP_PARALLELISM", 0)
+        self._tfs_intra_op_parallelism = os.environ.get("SAGEMAKER_TFS_INTRA_OP_PARALLELISM", 0)
+        self._gunicorn_worker_class = os.environ.get("SAGEMAKER_GUNICORN_WORKER_CLASS", 'gevent')
 
         if _enable_multi_model_endpoint not in ["true", "false"]:
             raise ValueError("SAGEMAKER_MULTI_MODEL must be 'true' or 'false'")
@@ -79,19 +85,28 @@ class ServiceManager(object):
             parts = self._sagemaker_port_range.split("-")
             low = int(parts[0])
             hi = int(parts[1])
-            if low + 2 > hi:
+            self._tfs_grpc_port = []
+            self._tfs_rest_port = []
+            if low + 2 * self._tfs_instance_count > hi:
                 raise ValueError("not enough ports available in SAGEMAKER_SAFE_PORT_RANGE ({})"
                                  .format(self._sagemaker_port_range))
-            self._tfs_grpc_port = str(low)
-            self._tfs_rest_port = str(low + 1)
+            self._tfs_grpc_port_range = "{}-{}".format(low,
+                                                       low + 2 * self._tfs_instance_count)
+            self._tfs_rest_port_range = "{}-{}".format(low + 1,
+                                                       low + 2 * self._tfs_instance_count + 1)
+            for i in range(self._tfs_instance_count):
+                self._tfs_grpc_port.append(str(low + 2 * i))
+                self._tfs_rest_port.append(str(low + 2 * i + 1))
+            # set environment variable for python service
+            os.environ["TFS_GRPC_PORT_RANGE"] = self._tfs_grpc_port_range
+            os.environ["TFS_REST_PORT_RANGE"] = self._tfs_rest_port_range
         else:
             # just use the standard default ports
-            self._tfs_grpc_port = "9000"
-            self._tfs_rest_port = "8501"
-
-        # set environment variable for python service
-        os.environ["TFS_GRPC_PORT"] = self._tfs_grpc_port
-        os.environ["TFS_REST_PORT"] = self._tfs_rest_port
+            self._tfs_grpc_port = ["9000"]
+            self._tfs_rest_port = ["8501"]
+            # set environment variable for python service
+            os.environ["TFS_GRPC_PORT_RANGE"] = "9000-9000"
+            os.environ["TFS_REST_PORT_RANGE"] = "8501-8501"
 
     def _need_python_service(self):
         if os.path.exists(INFERENCE_PATH):
@@ -171,12 +186,15 @@ class ServiceManager(object):
                         raise ChildProcessError("failed to install required packages.")
 
         gunicorn_command = (
-            "gunicorn -b unix:/tmp/gunicorn.sock -k gevent --chdir /sagemaker "
+            "gunicorn -b unix:/tmp/gunicorn.sock -k {} --chdir /sagemaker "
             "--workers {} --threads {} "
-            "{}{} -e TFS_GRPC_PORT={} -e SAGEMAKER_MULTI_MODEL={} -e SAGEMAKER_SAFE_PORT_RANGE={} "
-            "python_service:app").format(self._gunicorn_workers, self._gunicorn_threads,
+            "{}{} -e TFS_GRPC_PORT_RANGE={} -e TFS_REST_PORT_RANGE={} "
+            "-e SAGEMAKER_MULTI_MODEL={} -e SAGEMAKER_SAFE_PORT_RANGE={} "
+            "python_service:app").format(self._gunicorn_worker_class,
+                                         self._gunicorn_workers, self._gunicorn_threads,
                                          python_path_option, ",".join(python_path_content),
-                                         self._tfs_grpc_port, self._tfs_enable_multi_model_endpoint,
+                                         self._tfs_grpc_port_range, self._tfs_rest_port_range,
+                                         self._tfs_enable_multi_model_endpoint,
                                          self._sagemaker_port_range)
 
         log.info("gunicorn command: {}".format(gunicorn_command))
@@ -201,13 +219,22 @@ class ServiceManager(object):
                     os.makedirs(os.path.dirname(destination))
                 resource.meta.client.download_file(bucket, file.get("Key"), destination)
 
+    def _create_nginx_tfs_upstream(self):
+        indentation = "    "
+        tfs_upstream = ""
+        for port in self._tfs_rest_port:
+            tfs_upstream += "{}server localhost:{};\n".format(indentation, port)
+        tfs_upstream = tfs_upstream[len(indentation):-2]
+
+        return tfs_upstream
+
     def _create_nginx_config(self):
         template = self._read_nginx_template()
         pattern = re.compile(r"%(\w+)%")
 
         template_values = {
             "TFS_VERSION": self._tfs_version,
-            "TFS_REST_PORT": self._tfs_rest_port,
+            "TFS_UPSTREAM": self._create_nginx_tfs_upstream(),
             "TFS_DEFAULT_MODEL_NAME": self._tfs_default_model_name,
             "NGINX_HTTP_PORT": self._nginx_http_port,
             "NGINX_LOG_LEVEL": self._nginx_loglevel,
@@ -230,19 +257,22 @@ class ServiceManager(object):
 
             return template
 
+    def _enable_per_process_gpu_memory_fraction(self):
+        nvidia_smi_exist = os.path.exists("/usr/bin/nvidia-smi")
+        if self._tfs_instance_count > 1 and nvidia_smi_exist:
+            return True
+
+        return False
+
+    def _calculate_per_process_gpu_memory_fraction(self):
+        return round((1 - self._tfs_gpu_margin) / float(self._tfs_instance_count), 4)
+
     def _start_tfs(self):
         self._log_version("tensorflow_model_server --version", "tensorflow version info:")
-        cmd = tfs_utils.tfs_command(
-            self._tfs_grpc_port,
-            self._tfs_rest_port,
-            self._tfs_config_path,
-            self._tfs_enable_batching,
-            self._tfs_batching_config_path,
-        )
-        log.info("tensorflow serving command: {}".format(cmd))
-        p = subprocess.Popen(cmd.split())
-        log.info("started tensorflow serving (pid: %d)", p.pid)
-        self._tfs = p
+
+        for i in range(self._tfs_instance_count):
+            p = self._start_single_tfs(i)
+            self._tfs.append(p)
 
     def _start_gunicorn(self):
         self._log_version("gunicorn --version", "gunicorn version info:")
@@ -280,7 +310,8 @@ class ServiceManager(object):
         except OSError:
             pass
         try:
-            os.kill(self._tfs.pid, signal.SIGTERM)
+            for tfs in self._tfs:
+                os.kill(tfs.pid, signal.SIGTERM)
         except OSError:
             pass
 
@@ -304,6 +335,66 @@ class ServiceManager(object):
             yield
         finally:
             signal.alarm(0)
+
+    def _is_tfs_process(self, pid):
+        for p in self._tfs:
+            if p.pid == pid:
+                return True
+        return False
+
+    def _find_tfs_process(self, pid):
+        for index, p in enumerate(self._tfs):
+            if p.pid == pid:
+                return index
+        return None
+
+    def _restart_single_tfs(self, pid):
+        instance_id = self._find_tfs_process(pid)
+        if instance_id is None:
+            raise ValueError("Cannot find tfs with pid: {};".format(pid))
+        p = self._start_single_tfs(instance_id)
+        self._tfs[instance_id] = p
+
+    def _start_single_tfs(self, instance_id):
+        cmd = tfs_utils.tfs_command(
+            self._tfs_grpc_port[instance_id],
+            self._tfs_rest_port[instance_id],
+            self._tfs_config_path,
+            self._tfs_enable_batching,
+            self._tfs_batching_config_path,
+            tfs_intra_op_parallelism=self._tfs_intra_op_parallelism,
+            tfs_inter_op_parallelism=self._tfs_inter_op_parallelism,
+            tfs_enable_gpu_memory_fraction=self._enable_per_process_gpu_memory_fraction(),
+            tfs_gpu_memory_fraction=self._calculate_per_process_gpu_memory_fraction()
+        )
+        log.info("tensorflow serving command: {}".format(cmd))
+        p = subprocess.Popen(cmd.split())
+        log.info("started tensorflow serving (pid: %d)", p.pid)
+        return p
+
+    def _monitor(self):
+        while True:
+            pid, status = os.wait()
+
+            if self._state != "started":
+                break
+
+            if pid == self._nginx.pid:
+                log.warning("unexpected nginx exit (status: {}). restarting.".format(status))
+                self._start_nginx()
+
+            elif self._is_tfs_process(pid):
+                log.warning(
+                    "unexpected tensorflow serving exit (status: {}). restarting.".format(status))
+                try:
+                    self._restart_single_tfs(pid)
+                except (ValueError, OSError) as error:
+                    log.error("Failed to restart tensorflow serving. {}".format(error))
+
+            elif self._gunicorn and pid == self._gunicorn.pid:
+                log.warning("unexpected gunicorn exit (status: {}). restarting."
+                            .format(status))
+                self._start_gunicorn()
 
     def start(self):
         log.info("starting services")
@@ -331,27 +422,7 @@ class ServiceManager(object):
 
         self._start_nginx()
         self._state = "started"
-
-        while True:
-            pid, status = os.wait()
-
-            if self._state != "started":
-                break
-
-            if pid == self._nginx.pid:
-                log.warning("unexpected nginx exit (status: {}). restarting.".format(status))
-                self._start_nginx()
-
-            elif pid == self._tfs.pid:
-                log.warning(
-                    "unexpected tensorflow serving exit (status: {}). restarting.".format(status))
-                self._start_tfs()
-
-            elif self._gunicorn and pid == self._gunicorn.pid:
-                log.warning("unexpected gunicorn exit (status: {}). restarting."
-                            .format(status))
-                self._start_gunicorn()
-
+        self._monitor()
         self._stop()
 
 

--- a/docker/build_artifacts/sagemaker/tfs_utils.py
+++ b/docker/build_artifacts/sagemaker/tfs_utils.py
@@ -26,11 +26,11 @@ DEFAULT_ACCEPT_HEADER = "application/json"
 CUSTOM_ATTRIBUTES_HEADER = "X-Amzn-SageMaker-Custom-Attributes"
 
 Context = namedtuple("Context",
-                     "model_name, model_version, method, rest_uri, grpc_port, "
+                     "model_name, model_version, method, rest_uri, grpc_port, channel, "
                      "custom_attributes, request_content_type, accept_header, content_length")
 
 
-def parse_request(req, rest_port, grpc_port, default_model_name, model_name=None):
+def parse_request(req, rest_port, grpc_port, default_model_name, model_name=None, channel=None):
     tfs_attributes = parse_tfs_custom_attributes(req)
     tfs_uri = make_tfs_uri(rest_port, tfs_attributes, default_model_name, model_name)
 
@@ -42,6 +42,7 @@ def parse_request(req, rest_port, grpc_port, default_model_name, model_name=None
                       tfs_attributes.get("tfs-method"),
                       tfs_uri,
                       grpc_port,
+                      channel,
                       req.get_header(CUSTOM_ATTRIBUTES_HEADER),
                       req.get_header("Content-Type") or DEFAULT_CONTENT_TYPE,
                       req.get_header("Accept") or DEFAULT_ACCEPT_HEADER,
@@ -97,14 +98,21 @@ def tfs_command(tfs_grpc_port,
                 tfs_rest_port,
                 tfs_config_path,
                 tfs_enable_batching,
-                tfs_batching_config_file):
+                tfs_batching_config_file,
+                tfs_intra_op_parallelism=None,
+                tfs_inter_op_parallelism=None,
+                tfs_enable_gpu_memory_fraction=False,
+                tfs_gpu_memory_fraction=None):
     cmd = "tensorflow_model_server " \
           "--port={} " \
           "--rest_api_port={} " \
           "--model_config_file={} " \
-          "--max_num_load_retries=0 {}" \
+          "--max_num_load_retries=0 {} {} {} {}"\
         .format(tfs_grpc_port, tfs_rest_port, tfs_config_path,
-                get_tfs_batching_args(tfs_enable_batching, tfs_batching_config_file))
+                get_tfs_batching_args(tfs_enable_batching, tfs_batching_config_file),
+                get_tensorflow_intra_op_parallelism_args(tfs_intra_op_parallelism),
+                get_tensorflow_inter_op_parallelism_args(tfs_inter_op_parallelism),
+                get_tfs_gpu_mem_args(tfs_enable_gpu_memory_fraction, tfs_gpu_memory_fraction))
     return cmd
 
 
@@ -137,6 +145,27 @@ def get_tfs_batching_args(enable_batching, tfs_batching_config):
     if enable_batching:
         return "--enable_batching=true " \
                "--batching_parameters_file={}".format(tfs_batching_config)
+    else:
+        return ""
+
+
+def get_tensorflow_intra_op_parallelism_args(tfs_intra_op_parallelism):
+    if tfs_intra_op_parallelism:
+        return "--tensorflow_intra_op_parallelism={}".format(tfs_intra_op_parallelism)
+    else:
+        return ""
+
+
+def get_tensorflow_inter_op_parallelism_args(tfs_inter_op_parallelism):
+    if tfs_inter_op_parallelism:
+        return "--tensorflow_inter_op_parallelism={}".format(tfs_inter_op_parallelism)
+    else:
+        return ""
+
+
+def get_tfs_gpu_mem_args(enable_gpu_memory_fraction, gpu_memory_fraction):
+    if enable_gpu_memory_fraction and gpu_memory_fraction:
+        return "--per_process_gpu_memory_fraction={}".format(gpu_memory_fraction)
     else:
         return ""
 


### PR DESCRIPTION
*Description of changes:*

Implement new container environment which could expose additional parameters to help user optimize for throughput and fine tune container performance.

The feature that multiple of tensorflow model servers could handle parallel requests coming from different gunicorn workers could be supported in this release. And throughput will be improved based on different parameters tuned. 
Specifically, tunable parameters like`SAGEMAKER_GUNICORN_WORKERS`, `SAGEMAKER_TFS_INSTANCE_COUNT`, `SAGEMAKER_TFS_INTER_OP_PARALLELISM`, `SAGEMAKER_TFS_INTRA_OP_PARALLELISM` and etc.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
