### PR TITLE
To fix python sdk repo localmode tfs tests failing issue

### DIFF
--- a/docker/build_artifacts/sagemaker/serve.py
+++ b/docker/build_artifacts/sagemaker/serve.py
@@ -104,9 +104,11 @@ class ServiceManager(object):
             # just use the standard default ports
             self._tfs_grpc_port = ["9000"]
             self._tfs_rest_port = ["8501"]
+            self._tfs_grpc_port_range = "9000-9000"
+            self._tfs_rest_port_range = "8501-8501"
             # set environment variable for python service
-            os.environ["TFS_GRPC_PORT_RANGE"] = "9000-9000"
-            os.environ["TFS_REST_PORT_RANGE"] = "8501-8501"
+            os.environ["TFS_GRPC_PORT_RANGE"] = self._tfs_grpc_port_range
+            os.environ["TFS_REST_PORT_RANGE"] = self._tfs_rest_port_range
 
     def _need_python_service(self):
         if os.path.exists(INFERENCE_PATH):


### PR DESCRIPTION
*Issue #, if available:*
AttributeError: 'ServiceManager' object has no attribute '_tfs_grpc_port_range'

*Description of changes:*
Add '_tfs_grpc_port_range' when self._sagemaker_port_range is None

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
