### PR TITLE
set OMP_NUM_THREADS default value to 1

### DIFF
--- a/docker/build_artifacts/sagemaker/serve.py
+++ b/docker/build_artifacts/sagemaker/serve.py
@@ -65,6 +65,9 @@ class ServiceManager(object):
         self._tfs_intra_op_parallelism = os.environ.get("SAGEMAKER_TFS_INTRA_OP_PARALLELISM", 0)
         self._gunicorn_worker_class = os.environ.get("SAGEMAKER_GUNICORN_WORKER_CLASS", 'gevent')
 
+        if os.environ.get("OMP_NUM_THREADS") is None:
+            os.environ["OMP_NUM_THREADS"] = "1"
+
         if _enable_multi_model_endpoint not in ["true", "false"]:
             raise ValueError("SAGEMAKER_MULTI_MODEL must be 'true' or 'false'")
         self._tfs_enable_multi_model_endpoint = _enable_multi_model_endpoint == "true"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Set OMP_NUM_THREADS default value to 1

*Testing*
Checked the default value inside container
[ec2-user@ip-172-31-6-164 sagemaker-tensorflow-serving-container]$ docker exec -it fd2b0f0428ae /bin/bash
root@fd2b0f0428ae:/# ps aux
USER        PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
root          1  0.0  0.0  20132  3472 ?        Ss   18:46   0:00 /bin/bash /sagemaker/serve
root          6  0.1  0.0  82720 28472 ?        S    18:46   0:00 python3 /sagemaker/serve.py
root          9  0.0  0.0 3265944 52988 ?       Sl   18:46   0:00 tensorflow_model_server --port=9000 --rest_api_port=9001 --model_config_file=/sagema
root        350  0.0  0.0  40136  8028 ?        S    18:46   0:00 nginx: master process /usr/sbin/nginx -c /sagemaker/nginx.conf

root@fd2b0f0428ae:/# cat /proc/9/environ
PYTHONUNBUFFERED=1LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATHLANG=C.UTF-8SAGEMAKER_SAFE_PORT_RANGE=9000-9999HOSTNAME=fd2b0f0428aeSAGEMAKER_TFS_NGINX_LOGLEVEL=errorPWD=/HOME=/rootSAGEMAKER_TFS_VERSION=1.15DEBIAN_FRONTEND=noninteractiveMODEL_NAME=modelSAGEMAKER_BIND_TO_PORT=8080MODEL_BASE_PATH=/modelsPYTHONDONTWRITEBYTECODE=1SHLVL=1PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/sagemaker_=/usr/bin/python3OMP_NUM_THREADS=1TFS_GRPC_PORT_RANGE=9000-9002TFS_REST_PORT_RANGE=9001-9003root@fd2b0f0428ae:/# vim /proc/9/environ

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
