### PR TITLE
Adding gunicorn config file.

### DIFF
--- a/docker/build_artifacts/sagemaker/serve.py
+++ b/docker/build_artifacts/sagemaker/serve.py
@@ -201,7 +201,7 @@ class ServiceManager(object):
             "-e SAGEMAKER_TFS_WAIT_TIME_SECONDS={} "
             "python_service:app").format(self._gunicorn_worker_class,
                                          self._gunicorn_workers, self._gunicorn_threads,
-                                         self._build_gunicorn_config_file_option(),
+                                         self._use_gunicorn_config_file_option(),
                                          python_path_option, ",".join(python_path_content),
                                          self._tfs_grpc_port_range, self._tfs_rest_port_range,
                                          self._tfs_enable_multi_model_endpoint,
@@ -211,10 +211,11 @@ class ServiceManager(object):
         log.info("gunicorn command: {}".format(gunicorn_command))
         self._gunicorn_command = gunicorn_command
 
-    def _build_gunicorn_config_file_option(self):
+    def _use_gunicorn_config_file_option(self):
         gunicorn_config_file_exists = os.path.exists(GUNICORN_CONFIGURATION_PATH)
 
         if gunicorn_config_file_exists:
+            log.info("using the following config file: {}".format(GUNICORN_CONFIGURATION_PATH))
             return "-c {}".format(GUNICORN_CONFIGURATION_PATH)
 
         return ""

--- a/docker/build_artifacts/sagemaker/serve.py
+++ b/docker/build_artifacts/sagemaker/serve.py
@@ -172,7 +172,6 @@ class ServiceManager(object):
         if self._enable_python_service:
             lib_path_exists = os.path.exists(PYTHON_LIB_PATH)
             requirements_exists = os.path.exists(REQUIREMENTS_PATH)
-
             python_path_content = ["/opt/ml/model/code"]
             python_path_option = "--pythonpath "
 
@@ -195,8 +194,8 @@ class ServiceManager(object):
 
         gunicorn_command = (
             "gunicorn -b unix:/tmp/gunicorn.sock -k {} --chdir /sagemaker "
-            "--workers {} --threads {}"
-            "{}"
+            "--workers {} --threads {} "
+            "{} "
             "{}{} -e TFS_GRPC_PORT_RANGE={} -e TFS_REST_PORT_RANGE={} "
             "-e SAGEMAKER_MULTI_MODEL={} -e SAGEMAKER_SAFE_PORT_RANGE={} "
             "-e SAGEMAKER_TFS_WAIT_TIME_SECONDS={} "

--- a/docker/build_artifacts/sagemaker/serve.py
+++ b/docker/build_artifacts/sagemaker/serve.py
@@ -201,7 +201,7 @@ class ServiceManager(object):
             "-e SAGEMAKER_TFS_WAIT_TIME_SECONDS={} "
             "python_service:app").format(self._gunicorn_worker_class,
                                          self._gunicorn_workers, self._gunicorn_threads,
-                                         self._use_gunicorn_config_file_option(),
+                                         self._build_gunicorn_config_file_option(),
                                          python_path_option, ",".join(python_path_content),
                                          self._tfs_grpc_port_range, self._tfs_rest_port_range,
                                          self._tfs_enable_multi_model_endpoint,
@@ -211,7 +211,7 @@ class ServiceManager(object):
         log.info("gunicorn command: {}".format(gunicorn_command))
         self._gunicorn_command = gunicorn_command
 
-    def _use_gunicorn_config_file_option(self):
+    def _build_gunicorn_config_file_option(self):
         gunicorn_config_file_exists = os.path.exists(GUNICORN_CONFIGURATION_PATH)
 
         if gunicorn_config_file_exists:


### PR DESCRIPTION
*Description of changes:*

This change provides a better way to configure gunicorn in the serving container.

Instead of using ad-hoc env vars (see `SAGEMAKER_GUNICORN_WORKERS` or `SAGEMAKER_GUNICORN_THREADS`) we can use the configuration file approach ([https://docs.gunicorn.org/en/stable/settings.html#config-file](https://docs.gunicorn.org/en/stable/settings.html#config-file)).

In this way, it is possible to specify the configuration of gunicorn along with `code` of the model:
```
    model1
        |--[model_version_number]
            |--variables
            |--saved_model.pb
    model2
        |--[model_version_number]
            |--assets
            |--variables
            |--saved_model.pb
    code
        |--lib
            |--external_module
        |--inference.py
        |--gunicorn_config.py
```

The resulting `gunicorn_command` should look like something similar to this:
```
gunicorn -c /opt/ml/model/code/gunicorn_config.py [<additional_arg>,...] python_service:app
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
