### PR TITLE
fix: set default SAGEMAKER_SAFE_PORT_RANGE when it is missing

### DIFF
--- a/docker/build_artifacts/sagemaker/python_service.py
+++ b/docker/build_artifacts/sagemaker/python_service.py
@@ -98,13 +98,8 @@ class PythonServiceResource:
             data = json.loads(req.stream.read().decode("utf-8"))
             self._handle_load_model_post(res, data)
 
-    def _parse_sagemaker_port_range(self, port_range):
-        lower, upper = port_range.split('-')
-        lower = int(lower)
-        upper = int(upper)
-        if lower == upper:
-            return [lower]
-        return [lower + 2 * i for i in range(TFS_INSTANCE_COUNT)]
+    def _parse_sagemaker_port_range(self, string_ports):
+        return map(int, string_ports.split('-'))
 
     def _pick_port(self, ports):
         return str(random.choice(ports))


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change mainly fixes case when multiple TFS feature is utilized but SAGEMAKER_SAFE_PORT_RANGE is not set.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
