### PR TITLE
Use js_import instead of js_include

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -1,3 +1,4 @@
 {
-  "asi": true
+  "asi": true,
+  "esversion": 6
 }

--- a/docker/1.14/Dockerfile.eia
+++ b/docker/1.14/Dockerfile.eia
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM public.ecr.aws/e2s1w5p1/ubuntu:16.04
 LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
 
 ARG TFS_SHORT_VERSION=1.14

--- a/docker/build_artifacts/sagemaker/multi_model_utils.py
+++ b/docker/build_artifacts/sagemaker/multi_model_utils.py
@@ -21,7 +21,7 @@ DEFAULT_LOCK_FILE = "/sagemaker/lock-file.lock"
 
 @contextmanager
 def lock(path=DEFAULT_LOCK_FILE):
-    f = open(path, "w")
+    f = open(path, "w", encoding="utf8")
     fd = f.fileno()
     fcntl.lockf(fd, fcntl.LOCK_EX)
 

--- a/docker/build_artifacts/sagemaker/nginx.conf.template
+++ b/docker/build_artifacts/sagemaker/nginx.conf.template
@@ -15,7 +15,7 @@ http {
   include /etc/nginx/mime.types;
   default_type application/json;
   access_log /dev/stdout combined;
-  js_include tensorflow-serving.js;
+  js_import tensorflowServing.js;
 
   upstream tfs_upstream {
     %TFS_UPSTREAM%;
@@ -44,14 +44,17 @@ http {
     }
 
     location /ping {
+        js_content tensorflowServing.ping;
         %FORWARD_PING_REQUESTS%;
     }
 
     location /invocations {
+        js_content tensorflowServing.invocations;
         %FORWARD_INVOCATION_REQUESTS%;
     }
 
     location /models {
+        js_content tensorflowServing.models;
         proxy_pass http://gunicorn_upstream/models;
     }
 
@@ -62,3 +65,8 @@ http {
     keepalive_timeout 3;
   }
 }
+
+export default {invocations, ping, ping_without_model, return_error,
+  tfs_json_request, make_tfs_uri, parse_custom_attributes,
+  json_request, is_tfs_json, is_json_lines, generic_json_request,
+  json_lines_request, csv_request};

--- a/docker/build_artifacts/sagemaker/nginx.conf.template
+++ b/docker/build_artifacts/sagemaker/nginx.conf.template
@@ -70,3 +70,4 @@ export default {invocations, ping, ping_without_model, return_error,
   tfs_json_request, make_tfs_uri, parse_custom_attributes,
   json_request, is_tfs_json, is_json_lines, generic_json_request,
   json_lines_request, csv_request};
+  

--- a/docker/build_artifacts/sagemaker/nginx.conf.template
+++ b/docker/build_artifacts/sagemaker/nginx.conf.template
@@ -44,17 +44,14 @@ http {
     }
 
     location /ping {
-        js_content tensorflowServing.ping;
         %FORWARD_PING_REQUESTS%;
     }
 
     location /invocations {
-        js_content tensorflowServing.invocations;
         %FORWARD_INVOCATION_REQUESTS%;
     }
 
     location /models {
-        js_content tensorflowServing.models;
         proxy_pass http://gunicorn_upstream/models;
     }
 
@@ -65,9 +62,4 @@ http {
     keepalive_timeout 3;
   }
 }
-
-export default {invocations, ping, ping_without_model, return_error,
-  tfs_json_request, make_tfs_uri, parse_custom_attributes,
-  json_request, is_tfs_json, is_json_lines, generic_json_request,
-  json_lines_request, csv_request};
   

--- a/docker/build_artifacts/sagemaker/python_service.py
+++ b/docker/build_artifacts/sagemaker/python_service.py
@@ -150,7 +150,7 @@ class PythonServiceResource:
                 tfs_config_file = "/sagemaker/tfs-config/{}/model-config.cfg".format(model_name)
                 log.info("tensorflow serving model config: \n%s\n", tfs_config)
                 os.makedirs(os.path.dirname(tfs_config_file))
-                with open(tfs_config_file, "w") as f:
+                with open(tfs_config_file, "w", encoding="utf8") as f:
                     f.write(tfs_config)
 
                 batching_config_file = "/sagemaker/batching/{}/batching-config.cfg".format(

--- a/docker/build_artifacts/sagemaker/serve.py
+++ b/docker/build_artifacts/sagemaker/serve.py
@@ -24,8 +24,8 @@ from contextlib import contextmanager
 logging.basicConfig(level=logging.INFO)
 log = logging.getLogger(__name__)
 
-JS_PING = "js_content ping"
-JS_INVOCATIONS = "js_content invocations"
+JS_PING = "js_content tensorflowServing.ping"
+JS_INVOCATIONS = "js_content tensorflowServing.invocations"
 GUNICORN_PING = "proxy_pass http://gunicorn_upstream/ping"
 GUNICORN_INVOCATIONS = "proxy_pass http://gunicorn_upstream/invocations"
 MULTI_MODEL = "s" if os.environ.get("SAGEMAKER_MULTI_MODEL", "False").lower() == "true" else ""
@@ -159,7 +159,7 @@ class ServiceManager(object):
 
         log.info("tensorflow serving model config: \n%s\n", config)
 
-        with open(self._tfs_config_path, "w") as f:
+        with open(self._tfs_config_path, "w", encoding="utf8") as f:
             f.write(config)
 
     def _setup_gunicorn(self):
@@ -258,11 +258,11 @@ class ServiceManager(object):
         config = pattern.sub(lambda x: template_values[x.group(1)], template)
         log.info("nginx config: \n%s\n", config)
 
-        with open("/sagemaker/nginx.conf", "w") as f:
+        with open("/sagemaker/nginx.conf", "w", encoding="utf8") as f:
             f.write(config)
 
     def _read_nginx_template(self):
-        with open("/sagemaker/nginx.conf.template", "r") as f:
+        with open("/sagemaker/nginx.conf.template", "r", encoding="utf8") as f:
             template = f.read()
             if not template:
                 raise ValueError("failed to read nginx.conf.template")

--- a/docker/build_artifacts/sagemaker/tensorflowServing.js
+++ b/docker/build_artifacts/sagemaker/tensorflowServing.js
@@ -232,3 +232,8 @@ function csv_request(r) {
     builder.push(']}')
     tfs_json_request(r, builder.join(''))
 }
+
+export default {invocations, ping, ping_without_model, return_error,
+    tfs_json_request, make_tfs_uri, parse_custom_attributes,
+    json_request, is_tfs_json, is_json_lines, generic_json_request,
+    json_lines_request, csv_request};

--- a/docker/build_artifacts/sagemaker/tensorflowServing.js
+++ b/docker/build_artifacts/sagemaker/tensorflowServing.js
@@ -232,3 +232,8 @@ function csv_request(r) {
     builder.push(']}')
     tfs_json_request(r, builder.join(''))
 }
+
+export default {invocations, ping, ping_without_model, return_error, tfs_json_request,
+     make_tfs_uri, parse_custom_attributes, 
+     json_request, is_tfs_json, is_json_lines, 
+     generic_json_request, json_lines_request, csv_request}

--- a/docker/build_artifacts/sagemaker/tensorflowServing.js
+++ b/docker/build_artifacts/sagemaker/tensorflowServing.js
@@ -232,8 +232,3 @@ function csv_request(r) {
     builder.push(']}')
     tfs_json_request(r, builder.join(''))
 }
-
-export default {invocations, ping, ping_without_model, return_error, tfs_json_request,
-     make_tfs_uri, parse_custom_attributes, 
-     json_request, is_tfs_json, is_json_lines, 
-     generic_json_request, json_lines_request, csv_request}

--- a/docker/build_artifacts/sagemaker/tfs_utils.py
+++ b/docker/build_artifacts/sagemaker/tfs_utils.py
@@ -220,7 +220,7 @@ def create_batching_config(batching_config_file):
         config += "%s { value: %s }\n" % (batching_parameter.key, batching_parameter.value)
 
     log.info("batching config: \n%s\n", config)
-    with open(batching_config_file, "w") as f:
+    with open(batching_config_file, "w", encoding="utf8") as f:
         f.write(config)
 
 


### PR DESCRIPTION
*Issue #, if available:*
The njs function `js_include` has been obsolete starting njs `v0.7.1`
http://nginx.org/en/docs/http/ngx_http_js_module.html#js_include

Upgraded the code to use `js_import` in place of `js_include` which requires few changes to the `nginx.conf.template` and the naming of `.js` file. (described below)

*Description of changes:*
- Updated `nginx.conf.template` to use `js_import` instead of `js_include`
- Renamed `tensorflow-serving.js` to `tensorflowServing.js`
- Updated `nginx.conf.template` to use export definitions for the functions
- Fixed pylint errors by passing `utf-8` encoding while opening a file
- Fixed jshint errors by adding `esversion: 6` to `.jshlintrc` file. The `export` statement is available only from es6
- Pull Ubuntu16.04 docker image from ECR rather than ubuntu to avoid docker pull limit failures

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
