### PR TITLE
Add gunicorn timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,13 +618,13 @@ SAGEMAKER_TFS_MAX_ENQUEUED_BATCHES="10000"
 The following environment variables can be set on a SageMaker Model or Transform Job if further configuration is required:
 
 [Configures](https://docs.gunicorn.org/en/stable/settings.html#loglevel)
-the logging level for GUnicorn.
+the logging level for Gunicorn.
 ```bash
 # Defaults to "info"
 SAGEMAKER_GUNICORN_LOGLEVEL="debug"
 ```
 [Configures](https://docs.gunicorn.org/en/stable/settings.html#timeout)
-how long a GUnicorn worker may be silent before it is killed and restarted.
+how long a Gunicorn worker may be silent before it is killed and restarted.
 ```bash
 # Defaults to 30.
 SAGEMAKER_GUNICORN_TIMEOUT_SECONDS="60"

--- a/README.md
+++ b/README.md
@@ -42,7 +42,9 @@ For notebook examples, see: [Amazon SageMaker Examples](https://github.com/awsla
 3. [Running the tests](#running-the-tests)
 4. [Pre/Post-Processing](#pre/post-processing)
 5. [Deploying a TensorFlow Serving Model](#deploying-a-tensorflow-serving-model)
-6. [Deploying to Multi-Model Endpoint](#deploying-to-multi-model-endpoint)
+6. [Enable Batching](#enabling-batching)
+7. [Other Configurable Environment Variables](#other-configurable-environment-variables)
+8. [Deploying to Multi-Model Endpoint](#deploying-to-multi-model-endpoint)
 
 ## Getting Started
 
@@ -610,6 +612,16 @@ SAGEMAKER_TFS_NUM_BATCH_THREADS="16"
 # Defaults to number of CPUs for real-time inference,
 # or arbitrarily large for batch transform (because batch transform).
 SAGEMAKER_TFS_MAX_ENQUEUED_BATCHES="10000"
+```
+
+## Other Configurable Environment Variables
+The following environment variables can be set on a SageMaker Model or Transform Job if further configuration is required:
+
+```bash
+# Configures how long to wait in seconds for GUnicorn
+# to finish starting up before timing out.
+# Defaults to 30.
+SAGEMAKER_GUNICORN_SETUP_TIMEOUT_SECONDS="60"
 ```
 
 ## Deploying to Multi-Model Endpoint

--- a/README.md
+++ b/README.md
@@ -618,6 +618,11 @@ SAGEMAKER_TFS_MAX_ENQUEUED_BATCHES="10000"
 The following environment variables can be set on a SageMaker Model or Transform Job if further configuration is required:
 
 ```bash
+# Configures the logging level for GUnicorn.
+# Valid values can be found here: https://docs.gunicorn.org/en/stable/settings.html#loglevel
+# Defaults to "info"
+SAGEMAKER_GUNICORN_LOGLEVEL="debug"
+
 # Configures how long to wait in seconds for GUnicorn
 # to finish starting up before timing out.
 # Defaults to 30.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ For notebook examples, see: [Amazon SageMaker Examples](https://github.com/awsla
 4. [Pre/Post-Processing](#pre/post-processing)
 5. [Deploying a TensorFlow Serving Model](#deploying-a-tensorflow-serving-model)
 6. [Enable Batching](#enabling-batching)
-7. [Other Configurable Environment Variables](#other-configurable-environment-variables)
+7. [Configurable SageMaker Environment Variables](#configurable-sagemaker-environment-variables)
 8. [Deploying to Multi-Model Endpoint](#deploying-to-multi-model-endpoint)
 
 ## Getting Started
@@ -614,14 +614,21 @@ SAGEMAKER_TFS_NUM_BATCH_THREADS="16"
 SAGEMAKER_TFS_MAX_ENQUEUED_BATCHES="10000"
 ```
 
-## Other Configurable Environment Variables
+## Configurable SageMaker Environment Variables
 The following environment variables can be set on a SageMaker Model or Transform Job if further configuration is required:
 
 ```bash
 # Configures the logging level for GUnicorn.
-# Valid values can be found here: https://docs.gunicorn.org/en/stable/settings.html#loglevel
+# When looking to set this environment variable, please refer to:
+# https://docs.gunicorn.org/en/stable/settings.html#loglevel
 # Defaults to "info"
 SAGEMAKER_GUNICORN_LOGLEVEL="debug"
+
+# Configures how long a GUnicorn worker may be silent before it is killed and restarted.
+# When looking to set this environment variable, please refer to:
+# https://docs.gunicorn.org/en/stable/settings.html#timeout
+# Defaults to 30.
+SAGEMAKER_GUNICORN_TIMEOUT_SECONDS="60"
 
 # Configures how long to wait in seconds for GUnicorn
 # to finish starting up before timing out.

--- a/README.md
+++ b/README.md
@@ -617,16 +617,15 @@ SAGEMAKER_TFS_MAX_ENQUEUED_BATCHES="10000"
 ## Configurable SageMaker Environment Variables
 The following environment variables can be set on a SageMaker Model or Transform Job if further configuration is required:
 
+When setting this environment variable, please refer to [this.](https://docs.gunicorn.org/en/stable/settings.html#loglevel)
 ```bash
 # Configures the logging level for GUnicorn.
-# When looking to set this environment variable, please refer to:
-# https://docs.gunicorn.org/en/stable/settings.html#loglevel
 # Defaults to "info"
 SAGEMAKER_GUNICORN_LOGLEVEL="debug"
-
+```
+When setting this environment variable, please refer to [this.](https://docs.gunicorn.org/en/stable/settings.html#timeout)
+```bash
 # Configures how long a GUnicorn worker may be silent before it is killed and restarted.
-# When looking to set this environment variable, please refer to:
-# https://docs.gunicorn.org/en/stable/settings.html#timeout
 # Defaults to 30.
 SAGEMAKER_GUNICORN_TIMEOUT_SECONDS="60"
 ```

--- a/README.md
+++ b/README.md
@@ -629,11 +629,6 @@ SAGEMAKER_GUNICORN_LOGLEVEL="debug"
 # https://docs.gunicorn.org/en/stable/settings.html#timeout
 # Defaults to 30.
 SAGEMAKER_GUNICORN_TIMEOUT_SECONDS="60"
-
-# Configures how long to wait in seconds for GUnicorn
-# to finish starting up before timing out.
-# Defaults to 30.
-SAGEMAKER_GUNICORN_SETUP_TIMEOUT_SECONDS="60"
 ```
 
 ## Deploying to Multi-Model Endpoint

--- a/README.md
+++ b/README.md
@@ -617,15 +617,15 @@ SAGEMAKER_TFS_MAX_ENQUEUED_BATCHES="10000"
 ## Configurable SageMaker Environment Variables
 The following environment variables can be set on a SageMaker Model or Transform Job if further configuration is required:
 
-When setting this environment variable, please refer to [this.](https://docs.gunicorn.org/en/stable/settings.html#loglevel)
+[Configures](https://docs.gunicorn.org/en/stable/settings.html#loglevel)
+the logging level for GUnicorn.
 ```bash
-# Configures the logging level for GUnicorn.
 # Defaults to "info"
 SAGEMAKER_GUNICORN_LOGLEVEL="debug"
 ```
-When setting this environment variable, please refer to [this.](https://docs.gunicorn.org/en/stable/settings.html#timeout)
+[Configures](https://docs.gunicorn.org/en/stable/settings.html#timeout)
+how long a GUnicorn worker may be silent before it is killed and restarted.
 ```bash
-# Configures how long a GUnicorn worker may be silent before it is killed and restarted.
 # Defaults to 30.
 SAGEMAKER_GUNICORN_TIMEOUT_SECONDS="60"
 ```

--- a/docker/build_artifacts/sagemaker/serve.py
+++ b/docker/build_artifacts/sagemaker/serve.py
@@ -63,9 +63,9 @@ class ServiceManager(object):
         self._tfs_inter_op_parallelism = os.environ.get("SAGEMAKER_TFS_INTER_OP_PARALLELISM", 0)
         self._tfs_intra_op_parallelism = os.environ.get("SAGEMAKER_TFS_INTRA_OP_PARALLELISM", 0)
         self._gunicorn_worker_class = os.environ.get("SAGEMAKER_GUNICORN_WORKER_CLASS", "gevent")
-        self._gunicorn_setup_timeout_seconds = os.environ.get(
+        self._gunicorn_setup_timeout_seconds = int(os.environ.get(
             "SAGEMAKER_GUNICORN_SETUP_TIMEOUT_SECONDS", 30
-        )
+        ))
 
         if os.environ.get("OMP_NUM_THREADS") is None:
             os.environ["OMP_NUM_THREADS"] = "1"

--- a/docker/build_artifacts/sagemaker/serve.py
+++ b/docker/build_artifacts/sagemaker/serve.py
@@ -51,6 +51,7 @@ class ServiceManager(object):
         self._sagemaker_port_range = os.environ.get("SAGEMAKER_SAFE_PORT_RANGE", None)
         self._gunicorn_workers = os.environ.get("SAGEMAKER_GUNICORN_WORKERS", 1)
         self._gunicorn_threads = os.environ.get("SAGEMAKER_GUNICORN_THREADS", 1)
+        self._gunicorn_loglevel = os.environ.get("SAGEMAKER_GUNICORN_LOGLEVEL", "info")
         self._tfs_config_path = "/sagemaker/model-config.cfg"
         self._tfs_batching_config_path = "/sagemaker/batching-config.cfg"
 
@@ -204,7 +205,7 @@ class ServiceManager(object):
 
         gunicorn_command = (
             "gunicorn -b unix:/tmp/gunicorn.sock -k {} --chdir /sagemaker "
-            "--workers {} --threads {} "
+            "--workers {} --threads {} --log-level {} "
             "{}{} -e TFS_GRPC_PORTS={} -e TFS_REST_PORTS={} "
             "-e SAGEMAKER_MULTI_MODEL={} -e SAGEMAKER_SAFE_PORT_RANGE={} "
             "-e SAGEMAKER_TFS_WAIT_TIME_SECONDS={} "
@@ -213,6 +214,7 @@ class ServiceManager(object):
             self._gunicorn_worker_class,
             self._gunicorn_workers,
             self._gunicorn_threads,
+            self._gunicorn_loglevel,
             python_path_option,
             ",".join(python_path_content),
             self._tfs_grpc_concat_ports,

--- a/docker/build_artifacts/sagemaker/serve.py
+++ b/docker/build_artifacts/sagemaker/serve.py
@@ -64,9 +64,12 @@ class ServiceManager(object):
         self._tfs_inter_op_parallelism = os.environ.get("SAGEMAKER_TFS_INTER_OP_PARALLELISM", 0)
         self._tfs_intra_op_parallelism = os.environ.get("SAGEMAKER_TFS_INTRA_OP_PARALLELISM", 0)
         self._gunicorn_worker_class = os.environ.get("SAGEMAKER_GUNICORN_WORKER_CLASS", "gevent")
-        self._gunicorn_setup_timeout_seconds = int(os.environ.get(
-            "SAGEMAKER_GUNICORN_SETUP_TIMEOUT_SECONDS", 30
-        ))
+        self._gunicorn_timeout_seconds = int(
+            os.environ.get("SAGEMAKER_GUNICORN_TIMEOUT_SECONDS", 30)
+        )
+        self._gunicorn_setup_timeout_seconds = int(
+            os.environ.get("SAGEMAKER_GUNICORN_SETUP_TIMEOUT_SECONDS", 30)
+        )
 
         if os.environ.get("OMP_NUM_THREADS") is None:
             os.environ["OMP_NUM_THREADS"] = "1"
@@ -205,7 +208,7 @@ class ServiceManager(object):
 
         gunicorn_command = (
             "gunicorn -b unix:/tmp/gunicorn.sock -k {} --chdir /sagemaker "
-            "--workers {} --threads {} --log-level {} "
+            "--workers {} --threads {} --log-level {} --timeout {} "
             "{}{} -e TFS_GRPC_PORTS={} -e TFS_REST_PORTS={} "
             "-e SAGEMAKER_MULTI_MODEL={} -e SAGEMAKER_SAFE_PORT_RANGE={} "
             "-e SAGEMAKER_TFS_WAIT_TIME_SECONDS={} "
@@ -215,6 +218,8 @@ class ServiceManager(object):
             self._gunicorn_workers,
             self._gunicorn_threads,
             self._gunicorn_loglevel,
+            self._gunicorn_timeout_seconds,
+            self._gunicorn_setup_timeout_seconds,
             python_path_option,
             ",".join(python_path_content),
             self._tfs_grpc_concat_ports,

--- a/docker/build_artifacts/sagemaker/serve.py
+++ b/docker/build_artifacts/sagemaker/serve.py
@@ -63,6 +63,9 @@ class ServiceManager(object):
         self._tfs_inter_op_parallelism = os.environ.get("SAGEMAKER_TFS_INTER_OP_PARALLELISM", 0)
         self._tfs_intra_op_parallelism = os.environ.get("SAGEMAKER_TFS_INTRA_OP_PARALLELISM", 0)
         self._gunicorn_worker_class = os.environ.get("SAGEMAKER_GUNICORN_WORKER_CLASS", "gevent")
+        self._gunicorn_setup_timeout_seconds = os.environ.get(
+            "SAGEMAKER_GUNICORN_SETUP_TIMEOUT_SECONDS", 30
+        )
 
         if os.environ.get("OMP_NUM_THREADS") is None:
             os.environ["OMP_NUM_THREADS"] = "1"
@@ -449,7 +452,7 @@ class ServiceManager(object):
             self._setup_gunicorn()
             self._start_gunicorn()
             # make sure gunicorn is up
-            with self._timeout(seconds=30):
+            with self._timeout(seconds=self._gunicorn_setup_timeout_seconds):
                 self._wait_for_gunicorn()
 
         self._start_nginx()

--- a/docker/build_artifacts/sagemaker/serve.py
+++ b/docker/build_artifacts/sagemaker/serve.py
@@ -219,7 +219,6 @@ class ServiceManager(object):
             self._gunicorn_threads,
             self._gunicorn_loglevel,
             self._gunicorn_timeout_seconds,
-            self._gunicorn_setup_timeout_seconds,
             python_path_option,
             ",".join(python_path_content),
             self._tfs_grpc_concat_ports,

--- a/docker/build_artifacts/sagemaker/serve.py
+++ b/docker/build_artifacts/sagemaker/serve.py
@@ -67,9 +67,6 @@ class ServiceManager(object):
         self._gunicorn_timeout_seconds = int(
             os.environ.get("SAGEMAKER_GUNICORN_TIMEOUT_SECONDS", 30)
         )
-        self._gunicorn_setup_timeout_seconds = int(
-            os.environ.get("SAGEMAKER_GUNICORN_SETUP_TIMEOUT_SECONDS", 30)
-        )
 
         if os.environ.get("OMP_NUM_THREADS") is None:
             os.environ["OMP_NUM_THREADS"] = "1"
@@ -458,7 +455,7 @@ class ServiceManager(object):
             self._setup_gunicorn()
             self._start_gunicorn()
             # make sure gunicorn is up
-            with self._timeout(seconds=self._gunicorn_setup_timeout_seconds):
+            with self._timeout(seconds=self._gunicorn_timeout_seconds):
                 self._wait_for_gunicorn()
 
         self._start_nginx()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Makes the GUnicorn startup timeout configurable via an environment variable. I also updated the readme to include a section that details configurable env vars like this one that do not fit under current sections.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
