### PR TITLE
Swap order of processing json_request to prevent bad jsonlines request.

### DIFF
--- a/docker/1.15/Dockerfile.gpu
+++ b/docker/1.15/Dockerfile.gpu
@@ -32,7 +32,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Fix cuda repo's GPG key. Nvidia is no longer updating the machine-learning repo.
 # Need to manually pull and install necessary debs to continue using these versions.
 RUN rm /etc/apt/sources.list.d/cuda.list \
-&& rm /etc/apt/sources.list.d/nvidia-ml.list \
 && apt-key del 7fa2af80 \
 && apt-get update && apt-get install -y --no-install-recommends wget \
 && wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-keyring_1.0-1_all.deb \

--- a/docker/2.1/Dockerfile.gpu
+++ b/docker/2.1/Dockerfile.gpu
@@ -30,7 +30,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Fix cuda repo's GPG key. Nvidia is no longer updating the machine-learning repo.
 # Need to manually pull and install necessary debs to continue using these versions.
 RUN rm /etc/apt/sources.list.d/cuda.list \
-&& rm /etc/apt/sources.list.d/nvidia-ml.list \
 && apt-key del 7fa2af80 \
 && apt-get update && apt-get install -y --no-install-recommends wget \
 && wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-keyring_1.0-1_all.deb \

--- a/docker/build_artifacts/sagemaker/tensorflowServing.js
+++ b/docker/build_artifacts/sagemaker/tensorflowServing.js
@@ -144,8 +144,6 @@ function json_request(r) {
         tfs_json_request(r, data)
     } else if (is_json_lines(data)) {
         json_lines_request(r, data)
-    } else if (is_tfs_json(data)) {
-        tfs_json_request(r, data)
     } else {
         generic_json_request(r, data)
     }

--- a/docker/build_artifacts/sagemaker/tensorflowServing.js
+++ b/docker/build_artifacts/sagemaker/tensorflowServing.js
@@ -140,7 +140,9 @@ function parse_custom_attributes(r) {
 function json_request(r) {
     var data = r.requestBody
 
-    if (is_json_lines(data)) {
+    if (is_tfs_json(data)) {
+        tfs_json_request(r, data)
+    } else if (is_json_lines(data)) {
         json_lines_request(r, data)
     } else if (is_tfs_json(data)) {
         tfs_json_request(r, data)

--- a/test/integration/local/test_container.py
+++ b/test/integration/local/test_container.py
@@ -127,6 +127,22 @@ def test_predict_two_instances():
     assert y == {"predictions": [[3.5, 4.0, 5.5], [3.5, 4.0, 5.5]]}
 
 
+def test_predict_instance_jsonlines_input_error():
+    """
+    Test with input that previously triggered jsonlines code in tensorflowServing.js
+    Will still produce error - but error should be 'Type: String is not of expected type: float'
+    """
+    x = {"instances": ["]["]}
+
+    y = make_request(json.dumps(x))
+    assert (
+        "error" in y
+        and y["error"]
+        == "Failed to process element: 0 of 'instances' list. Error: Invalid argument:"
+        + ' JSON Value: "][" Type: String is not of expected type: float'
+    )
+
+
 def test_predict_jsons_json_content_type():
     x = "[1.0, 2.0, 5.0]\n[1.0, 2.0, 5.0]"
     y = make_request(x)

--- a/test/integration/local/test_container.py
+++ b/test/integration/local/test_container.py
@@ -133,7 +133,6 @@ def test_predict_instance_jsonlines_input_error():
     Will still produce error - but error should be 'Type: String is not of expected type: float'
     """
     x = {"instances": ["]["]}
-
     y = make_request(json.dumps(x))
     assert (
         "error" in y


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Swaps order on how json requests are processed. This should prevent valid TFS requests from being processed as if its a jsonlines type request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
